### PR TITLE
Readding Greasepencil mark for when BCE Aimpoint is deactivated

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -285,7 +285,7 @@ class CfgVehicles
 		{
 			class HUD
 			{
-				getin="if (((_this # 0) animationPhase 'Addcrosshair') != 0) then{(_this # 0) animate ['Addcrosshair', 0];};";
+				getin="if (((_this # 0) animationPhase 'Addcrosshair') != 0 && BCE_HUD_fn ) then {(_this # 0) animate ['Addcrosshair', 0];} else {(_this # 0) animate ['Addcrosshair', 1]};";
 			};
 		};
 	};
@@ -316,7 +316,7 @@ class CfgVehicles
 			{
 				class HUD
 				{
-					getin="if (((_this # 0) animationPhase 'Addcrosshair') != 0) then{(_this # 0) animate ['Addcrosshair', 0];};";
+					getin="if (((_this # 0) animationPhase 'Addcrosshair') != 0 && BCE_HUD_fn ) then {(_this # 0) animate ['Addcrosshair', 0];} else {(_this # 0) animate ['Addcrosshair', 1]};";
 				};
 			};
 		};


### PR DESCRIPTION
Untested, will be done tonight.

Closes #28 

Recreated a fix I've done couple weeks back, but lost.
This PR will readd the default aiming grease pencil mark for the RHS AH-6M and MELB AH-6M in case BCE Aimdot is deactivated.
Should also work when you disable the setting midgame and reenter the Airframe.

getin="if (((_this # 0) animationPhase 'Addcrosshair') != 0 && BCE_HUD_fn ) then {(_this # 0) animate ['Addcrosshair', 0];} else {(_this # 0) animate ['Addcrosshair', 1]};";

Thanks
(First GIT PR ever, so please excuse any try & error)