### PR TITLE
Fix `BCE_Marker_Color` not found on cTab TAD

### DIFF
--- a/addons/Compat_cTab/functions/EH_handlers/fn_OnDrawbftTAD.sqf
+++ b/addons/Compat_cTab/functions/EH_handlers/fn_OnDrawbftTAD.sqf
@@ -17,7 +17,7 @@ ctrlMapAnimCommit _cntrlScreen;
 
 //- Only for "ICON"
 	private _mapScale = ctrlMapScale _cntrlScreen;
-	private _ColorCache = uiNamespace getVariable "BCE_Marker_Color";
+	// private _ColorCache = uiNamespace getVariable "BCE_Marker_Color";
 	{
 		private _markerShape = MarkerShape _x;
 		private _config = configFile >> "CfgMarkers" >> markerType _x;
@@ -30,12 +30,13 @@ ctrlMapAnimCommit _cntrlScreen;
 		private _markerColor = markerColor _x;
 		private _markerChannel = markerChannel _x;
 		
-		private _color = [];
+		private _color =+ _markerColor call BCE_fnc_getMarkerColor;
+		/* private _color = [];
 		{
 			if (_markerColor == (_x # 0)) exitWith {
 				_color = _x # 1;
 			};
-		} count _ColorCache;
+		} count _ColorCache; */
 
 		private _onSameChannel = [true, _markerChannel == currentChannel || _markerChannel < 0] select isMultiplayer;
 		_color set [3, [0.4, markerAlpha _x] select _onSameChannel];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized color handling logic in the compatibility addon to use an updated retrieval method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->