### PR TITLE
Fix fn_drawBftMarkers error during gameplay

### DIFF
--- a/addons/Compat_cTab/functions/fn_drawBftMarkers.sqf
+++ b/addons/Compat_cTab/functions/fn_drawBftMarkers.sqf
@@ -133,7 +133,7 @@ if (_mode != 2) then {
 			_ctrlScreen drawIcon [_x # 1,cTabColorBlue,_pos,cTabIconSize,cTabIconSize,0,_text,0,cTabTxtSize,"TahomaB","right"];
 			_ctrlScreen drawIcon [_x # 2,cTabColorBlue,_pos,cTabGroupOverlayIconSize,cTabGroupOverlayIconSize,0,"",0,cTabTxtSize,"TahomaB","right"];
 		};
-	} count cTabBFTgroups;
+	} forEach cTabBFTgroups;
 };
 
 // ------------------ MEMBERS ------------------
@@ -181,8 +181,7 @@ if (_mode != 2) then {
 			_ctrlScreen drawIcon ["\A3\ui_f\data\map\Markers\System\dummy_ca.paa",_teamColor,_pos,cTabIconManSize,cTabIconManSize,0,_x # 4,0,cTabTxtSize,"TahomaB","right"];
 		};
 	};
-	false
-} count cTabBFTmembers;
+} forEach cTabBFTmembers;
 
 // ------------------ ADD LABEL TO VEHICLES WITH MOUNTED GROUPS / MEMBERS ------------------
 


### PR DESCRIPTION
Changes ensure that the `fn_drawBftMarkers` function processes `cTabBFTgroups` and `cTabBFTmembers` correctly by replacing `count` with `forEach`. This resolves the error encountered mid gameplay.

Fixes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal iteration logic for BFT marker group and member display rendering to enhance code efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->