### PR TITLE
Fix cTab map drawing for RECTANGLE and ELLIPSE

### DIFF
--- a/addons/Compat_MapTools/functions/fn_SMT_markHouses.sqf
+++ b/addons/Compat_MapTools/functions/fn_SMT_markHouses.sqf
@@ -44,8 +44,6 @@ private _EH = _map ctrlAddEventHandler ["Draw",{
 
 
 	private _color = if (_iscTab) then {
-		// private _MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
-    // _MarkerColorCache # lbCurSel _colorLb # 0
 		private _colorLb = _display displayCtrl (17000 + 1090);
     _colorLb lbData (lbCurSel _colorLb)
 	} else {

--- a/addons/Compat_MapTools/functions/fn_SMT_placeGrid.sqf
+++ b/addons/Compat_MapTools/functions/fn_SMT_placeGrid.sqf
@@ -208,15 +208,9 @@ private _EH = _map ctrlAddEventHandler ["Draw",{
 		private _colorLb = _display displayCtrl (17000 + 1090);
     (_colorLb lbData (lbCurSel _colorLb)) call BCE_fnc_getMarkerColor
 	} else {
-		// private _colorLb = (_display displayCtrl 2302) controlsGroupCtrl 1090;
-		// private _class = configName (("true" configClasses (configFile >> "CfgMarkerColors")) # (_colorLb lbValue lbCurSel _colorLb));
-		// (getArray (configFile >> "CfgMarkerColors" >> _class >> "color")) apply {
-		// 	if (_x isEqualType "") then {call compile _x} else {_x};
-		// };
 
 		private _colorLb = (_display displayCtrl 2302) controlsGroupCtrl 1090;
-		private _class = (uiNamespace getVariable ["BCE_Marker_Color_Array",[]]) # (_colorLb lbValue lbCurSel _colorLb);
-		_class call BCE_fnc_getMarkerColor # 0;
+		(_colorLb lbData (lbCurSel _colorLb)) call BCE_fnc_getMarkerColor
 	};
 	_color set [3,1];
 

--- a/addons/Compat_cTab/functions/Marker/fn_DrawArea.sqf
+++ b/addons/Compat_cTab/functions/Marker/fn_DrawArea.sqf
@@ -35,8 +35,9 @@ if (_LMB >= 1) then {
   } else {
     //- Draw Rectangle
     private _colorLb = _display displayCtrl (17000 + 1090);
-    private _MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
-    private _color = _MarkerColorCache # lbCurSel _colorLb # 1;
+    private _colorSel = _colorLb lbData lbCurSel _colorLb;
+
+		private _color = _colorSel call BCE_fnc_getMarkerColor;
     _color set [3, 0.3];
 
     private _PosA = _Pool # 0;
@@ -82,7 +83,6 @@ if (_LMB == 0 && _lastClick > -1) then {
   _brushes = _group controlsGroupCtrl 21;
 
   _colorLb = _display displayCtrl (17000 + 1090);
-  // _MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
   _color = _colorLb lbdata (lbCurSel _colorLb);
 
   //- Marker ID

--- a/addons/Compat_cTab/functions/Marker/fn_FinishEDIT_Marker.sqf
+++ b/addons/Compat_cTab/functions/Marker/fn_FinishEDIT_Marker.sqf
@@ -32,8 +32,6 @@ private _EDIT_color = _group controlsGroupCtrl 51;
       deleteMarker _marker;
 
     //- Data
-			// private _MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
-      // private _curSel_COLOR = _MarkerColorCache # lbCurSel _EDIT_color # 0;
 			private _curSel_COLOR = _EDIT_color lbData (lbCurSel _EDIT_color);
 
       switch true do {

--- a/addons/Compat_cTab/functions/fn_updateUserMarkerList.sqf
+++ b/addons/Compat_cTab/functions/fn_updateUserMarkerList.sqf
@@ -78,7 +78,6 @@ _list = nil;
 
 //- Get Marker Data for SIT
 	private _MarkerColorArr = uiNamespace getVariable ["BCE_Marker_Color_Array",[]];
-  // private _MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
   private _rawMarkersList = [cTab_userMarkerLists,call cTab_fnc_getPlayerEncryptionKey,[]] call cTab_fnc_getFromPairs;
 
   cTabUserMarkerList = _rawMarkersList apply {

--- a/addons/cTab/functions/Menu_Widget/fn_Update_MarkerItems.sqf
+++ b/addons/cTab/functions/Menu_Widget/fn_Update_MarkerItems.sqf
@@ -9,7 +9,6 @@ params ["_ctrl","_selectedIndex"];
 _display = ctrlParent _ctrl;
 _group = _display displayCtrl (17000 + 1300);
 _dropBox = _group controlsGroupCtrl 10;
-_MarkerColorCache = uiNamespace getVariable ["BCE_Marker_Color",[]];
 
 lbClear _dropBox;
 


### PR DESCRIPTION
Refactor the color selection logic for drawing shapes in the cTab map, removing unnecessary variable and improving clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined marker color retrieval mechanism across mapping components to use a consistent, direct approach rather than cached lookups, improving reliability and maintainability of marker color handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->