### PR TITLE
Make image embedded on Discord after taking a picture with ATAK

### DIFF
--- a/addons/Compat_Discord_API/XEH_PREP.hpp
+++ b/addons/Compat_Discord_API/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(upload_SSE_PictureToDiscord);

--- a/addons/Compat_Discord_API/XEH_postInit.sqf
+++ b/addons/Compat_Discord_API/XEH_postInit.sqf
@@ -5,7 +5,7 @@ if !(isMultiplayer) exitWith {};
 [
   "BCE_SSE_Webhook_Send_fn","CHECKBOX",
   [localize "STR_BCE_Send_SSE_Pic_Send"],
-  ["Better CAS Environment (cTab ATAK Camera)",localize "STR_BCE_Server_Side"],
+  ["Better CAS Environment (ScreenShot)",localize "STR_BCE_Server_Side"],
   false,
   1
 ] call CBA_fnc_addSetting;
@@ -25,7 +25,7 @@ if !(isMultiplayer) exitWith {};
   [
     "BCE_SSE_Webhook_list", "LIST",
     [localize "STR_BCE_Select_Webhook_SSE"],
-    ["Better CAS Environment (cTab ATAK Camera)",localize "STR_BCE_Server_Side"],
+    ["Better CAS Environment (ScreenShot)",localize "STR_BCE_Server_Side"],
     [
       _list,
       _list apply {str _x},

--- a/addons/Compat_Discord_API/XEH_postInit.sqf
+++ b/addons/Compat_Discord_API/XEH_postInit.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 
+#ifndef DEBUG_MODE_FULL
 if !(isMultiplayer) exitWith {};
+#endif
 
 [
   "BCE_SSE_Webhook_Send_fn","CHECKBOX",
@@ -9,6 +11,8 @@ if !(isMultiplayer) exitWith {};
   false,
   1
 ] call CBA_fnc_addSetting;
+
+["bce_took_screenshot", FUNC(upload_SSE_PictureToDiscord)] call CBA_fnc_addEventHandler;
 
 //- initiate for Server and Client
 0 spawn {

--- a/addons/Compat_Discord_API/XEH_preInit.sqf
+++ b/addons/Compat_Discord_API/XEH_preInit.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/Compat_Discord_API/config.cpp
+++ b/addons/Compat_Discord_API/config.cpp
@@ -24,3 +24,10 @@ class Extended_PostInit_EventHandlers
 		init = QUOTE(call COMPILE_FILE(XEH_postInit));
 	};
 };
+class Extended_PreInit_EventHandlers
+{
+	class ADDON
+	{
+		init = QUOTE(call COMPILE_FILE(XEH_PreInit));
+	};
+};

--- a/addons/Compat_Discord_API/functions/fnc_upload_SSE_PictureToDiscord.sqf
+++ b/addons/Compat_Discord_API/functions/fnc_upload_SSE_PictureToDiscord.sqf
@@ -1,0 +1,73 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: BCE_Compat_Discord_API_fnc_upload_SSE_PictureToDiscord
+Description:
+		Uploads a screenshot taken via the BCE ScreenShot Extension to Discord using the Discord API.
+
+Parameters:
+		_fileDir  - Directory of the image file <OBJECT>
+		_file  - The image file e.g. "myPicture.jpg" <OBJECT>
+
+Returns:
+		<BOOL>
+
+Examples
+		#LINK - addons/cTab/functions/ATAK/Camera/fn_ATAK_TakePicture.sqf
+
+Author:
+		Aaren
+---------------------------------------------------------------------------- */
+
+params ["_fileDir", "_file"];
+TRACE_1("fnc_upload_SSE_PictureToDiscord",_this);
+
+if !(BCE_SSE_Webhook_Send_fn || isNil "BCE_SSE_Webhook_list") exitWith {false};
+INFO_1("Uploading SSE Picture To Discord. Params '%1'",_this);
+
+[
+	{
+		params ["_fileDir","_fileName","_unit","_map"];
+		([_unit] call BCE_fnc_getUnitParams) params ["","_unitName","_title"];
+
+		//- Send Discord Message
+		[
+			BCE_SSE_Webhook_list,
+			"",
+			"",
+			"",
+			false,
+			_fileDir,
+			[
+				//- Embeds
+				[
+					format [localize "STR_BCE_SSE_OPERATION_NAME", missionName], //- [Title]
+					"", //- [Description]
+					"", //- [color]
+					true, //- [timestamp]
+					"", //- [AuthorName]
+					"", //- [AuthorUrl]
+					"", //- [AuthorIconUrl]
+					format ["attachment://%1", _fileName] //- [ImageUrl]
+				]
+			],
+			[ //- Fields for each Embed
+				[
+					[localize "STR_BCE_SSE_SERVER_NAME", format["`%1`",serverName], false],
+					[localize "STR_BCE_SSE_FROM", format ["```%1%2```", profileName, ["[" + _unitName + "]", ""] select (_unitName == "")],true],
+					["", "",true],
+					[format["“%1” :",_map], format ["```%1```", _unit call BIS_fnc_locationDescription],true],
+					["","",false],
+					[localize "STR_BCE_SSE_UNIT", format ["```%1```", [_title, localize "str_special_none"] select (_title == "")],true]
+				]
+			]
+		] call DiscordAPI_fnc_sendMessage;
+	}, 
+	[
+		_fileDir,
+		_file,
+		player,
+		worldName
+	], 1
+] call CBA_fnc_waitAndExecute;
+
+true

--- a/addons/Compat_Discord_API/functions/script_component.hpp
+++ b/addons/Compat_Discord_API/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/Compat_HateDigitalCamera/$PBOPREFIX$
+++ b/addons/Compat_HateDigitalCamera/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\BCE\addons\Compat_HateDigitalCamera

--- a/addons/Compat_HateDigitalCamera/config.cpp
+++ b/addons/Compat_HateDigitalCamera/config.cpp
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		authors[] = {"Aaren"};
+		url = ECSTRING(main,url);
+		requiredVersion = REQUIRED_VERSION;
+		//- #NOTE : Hate's Digital Camera
+		requiredAddons[]=
+		{
+			"HATE_DSLR" 
+		};
+		skipWhenMissingDependencies = 1;
+		units[] = {};
+		weapons[] = {};
+		VERSION_CONFIG;
+	};
+};
+
+class CfgFunctions
+{
+	class HATE
+	{
+		class CAMERA
+		{
+			class takePicture
+			{
+				file = QPATHTOF(functions\fn_takePicture.sqf);
+			};
+		};
+	};
+};

--- a/addons/Compat_HateDigitalCamera/functions/fn_takePicture.sqf
+++ b/addons/Compat_HateDigitalCamera/functions/fn_takePicture.sqf
@@ -1,0 +1,53 @@
+#include "\DSLR\functions\rsc\constants.h"
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: HATE_fnc_takePicture
+Description:
+		Overwrite original "HATE_fnc_takePicture" function.
+
+Parameters:
+		_unit  - Camera man <OBJECT>
+
+Returns:
+		<NONE>
+---------------------------------------------------------------------------- */
+
+TRACE_1("fn_takePicture",_this);
+
+private ["_unit","_screenshot"];
+_unit = _this select 0;
+
+
+if (cameraView == "gunner") then
+{
+	//Play shutter sound in 3D (for multiplayer reasons)
+	[player, [hateShutterSound, 15, 1]] remoteExec ["say3D", 0, false];
+
+	if (_unit getVariable [LALA_HATE_FLASH_ENABLED_VAR, LALA_HATE_FLASH_ENABLED_DEFAULT_VALUE]) then {
+		//flash script
+		DSLR_light = "#lightpoint" createVehicle getPos player;
+		DSLR_light setLightBrightness 0.6;
+		DSLR_light setLightAmbient [0.76,0.99,0.97];
+		DSLR_light setLightColor [0.98,0.99,0.81];
+		DSLR_light setLightUseFlare true;
+		DSLR_light setLightFlareSize 2;
+		DSLR_light setLightFlareMaxDistance 100;
+		DSLR_light lightAttachObject [player,[0,.1,1.7]];
+	};
+	sleep .1;
+	//Save screenshot to /profile directory/Screenshots with format YYYY_MM_DD_hh_mm_ss.png
+	screenshot "";
+
+	private _screenshot = [] call BCE_fnc_screenShot; //- Take picture
+  if (_screenshot isNotEqualTo []) then {
+		["bce_took_screenshot", _screenshot] call CBA_fnc_localEvent; //- upload to discord
+	};
+};
+
+sleep 0.4;
+
+private _dslr_light = missionNamespace getVariable ["DSLR_light", objNull];
+
+if (!isNull _dslr_light) then {
+	deleteVehicle DSLR_light;
+};

--- a/addons/Compat_HateDigitalCamera/functions/script_component.hpp
+++ b/addons/Compat_HateDigitalCamera/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/Compat_HateDigitalCamera/script_component.hpp
+++ b/addons/Compat_HateDigitalCamera/script_component.hpp
@@ -1,0 +1,15 @@
+#define COMPONENT Compat_HateDigitalCamera
+
+#include "..\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_MAIN
+    #define DEBUG_MODE_FULL
+#endif
+    #ifdef DEBUG_SETTINGS_MAIN
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MAIN
+#endif
+
+#include "..\main\script_macros.hpp"

--- a/addons/Core/CBA_Setting.hpp
+++ b/addons/Core/CBA_Setting.hpp
@@ -170,7 +170,7 @@
 [
 	"BCE_PicFileSize_edit", "EDITBOX",
 	[localize "STR_BCE_Select_PIC_FILE_SIZE"],
-	["Better CAS Environment (screenShot)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
+	["Better CAS Environment (ScreenShot)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
 	"25",
 	2,
 	{

--- a/addons/Core/CBA_Setting.hpp
+++ b/addons/Core/CBA_Setting.hpp
@@ -149,3 +149,32 @@
 	false,
 	1
 ] call CBA_fnc_addSetting;
+
+//- Set File type (cTab/ATAK)
+/* [
+	"BCE_PicFile_list", "LIST",
+	[localize "STR_BCE_Select_PIC_FILE"],
+	["Better CAS Environment (cTab ATAK Camera)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
+	[[0,1], ["jpg","png"], 0],
+	2
+] call CBA_fnc_addSetting; */
+
+[
+	"BCE_PicFilePath_edit", "EDITBOX",
+	[localize "STR_BCE_Select_PIC_FILE_PATH", localize "STR_BCE_Select_PIC_FILE_ToopTip"],
+	["Better CAS Environment (ScreenShot)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
+	"",
+	2
+] call CBA_fnc_addSetting;
+
+[
+	"BCE_PicFileSize_edit", "EDITBOX",
+	[localize "STR_BCE_Select_PIC_FILE_SIZE"],
+	["Better CAS Environment (screenShot)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
+	"25",
+	2,
+	{
+		private _return = "Arma_ScreenShot_Extension" callExtension ["MaxSize", [round parseNumber _this]];
+		Systemchat (_return # 0);
+	}
+] call CBA_fnc_addSetting;

--- a/addons/Core/Configs/CfgFunctions.hpp
+++ b/addons/Core/Configs/CfgFunctions.hpp
@@ -24,6 +24,7 @@ class CfgFunctions
 			class Check_Optics;
 			class Set_EnvironmentList;
 			class Turret_interSurface;
+			class screenShot;
 
 			class POS2Grid;
 			class Grid2POS;

--- a/addons/Core/functions/Components/fn_screenShot.sqf
+++ b/addons/Core/functions/Components/fn_screenShot.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: BCE_fnc_screenShot
+Description:
+		Takes a screenshot using the Arma_ScreenShot_Extension and returns the jpg file path.
+
+Parameters:
+		_fileName - File name  <STRING>
+
+Returns:
+		_fileDir - Extension returned picture directory.<STRING>
+		_file - Picture jpg file <STRING>
+		(Empty ARRAY if error occurred)
+
+Examples
+		(begin example)
+				["myPicture"] call BCE_fnc_screenShot
+		(end)
+
+Author:
+		Aaren
+---------------------------------------------------------------------------- */
+
+params [["_fileName", ""]];
+TRACE_1("fn_screenShot",_this);
+
+//- Use default _fileName => systemTime
+if (_fileName isEqualTo "") then {
+	private _time = systemTime apply {(["","0"] select (_x < 10)) + (str _x)};
+	_time resize 6;
+
+	_fileName = _time joinString "_";
+};
+
+private _file = _fileName  + ".jpg";
+private _fileDir = format [
+	"%1%2", 
+	[(BCE_PicFilePath_edit trim ["\", 2]) + "\",""] select (BCE_PicFilePath_edit == ""), 
+	_file
+];
+
+INFO_1("Try to take a screenShot via BCE screenShot extension. _fileName = '%1'",_fileName);
+
+private _return = toString parseSimpleArray ("Arma_ScreenShot_Extension" callExtension str (toArray _fileDir));
+
+//- Exit it if ERROR
+if ("error" in toLowerANSI _return) exitwith {
+	ERROR_1("ERROR from Taking Pictrue. %1",_fileDir);
+	[]
+};
+
+[_return, _file]

--- a/addons/cTab/CBA_Setting.hpp
+++ b/addons/cTab/CBA_Setting.hpp
@@ -1,31 +1,3 @@
-//- Set File type (cTab/ATAK)
-/* [
-	"BCE_PicFile_list", "LIST",
-	[localize "STR_BCE_Select_PIC_FILE"],
-	["Better CAS Environment (cTab ATAK Camera)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
-	[[0,1], ["jpg","png"], 0],
-	2
-] call CBA_fnc_addSetting; */
-
-[
-	"BCE_PicFilePath_edit", "EDITBOX",
-	[localize "STR_BCE_Select_PIC_FILE_PATH", localize "STR_BCE_Select_PIC_FILE_ToopTip"],
-	["Better CAS Environment (cTab ATAK Camera)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
-	"",
-	2
-] call CBA_fnc_addSetting;
-
-[
-	"BCE_PicFileSize_edit", "EDITBOX",
-	[localize "STR_BCE_Select_PIC_FILE_SIZE"],
-	["Better CAS Environment (cTab ATAK Camera)", localize "STR_BCE_Title_ATAK_CAM_Settings"],
-	"25",
-	2,
-	{
-		private _return = "Arma_ScreenShot_Extension" callExtension ["MaxSize", [round parseNumber _this]];
-		Systemchat (_return # 0);
-	}
-] call CBA_fnc_addSetting;
 //- cTab server side
 [
 	"BCE_cTab_Side_Display", "CHECKBOX",

--- a/addons/cTab/XEH_postInit.sqf
+++ b/addons/cTab/XEH_postInit.sqf
@@ -7,7 +7,7 @@ call BCE_fnc_cTab_postInit;
 
 //- Phone Camera
 [
-  "Better CAS Environment (cTab ATAK Camera)","ScreenShot",
+  "Better CAS Environment (ScreenShot)","ScreenShot",
   localize "STR_BCE_Take_ScreenShot",
   {
     if (IsPhoneCAM_ON && isnil{ctabifopen}) then {
@@ -19,7 +19,7 @@ call BCE_fnc_cTab_postInit;
 ] call cba_fnc_addKeybind;
 //- Flash Light
 [
-  "Better CAS Environment (cTab ATAK Camera)","FlashLight",
+  "Better CAS Environment (ScreenShot)","FlashLight",
   localize "STR_BCE_ATAK_FlashLight",
   {
     if (IsPhoneCAM_ON && isnil{ctabifopen}) then {

--- a/addons/cTab/functions/ATAK/Camera/fn_ATAK_CamInit.sqf
+++ b/addons/cTab/functions/ATAK/Camera/fn_ATAK_CamInit.sqf
@@ -49,7 +49,7 @@ _cam = switch _displayName do {
         ["STR_BCE_ATAK_FlashLight","FlashLight"]
       ] apply {
         _x params ["_fnc","_id"];
-        format [localize "STR_BCE_Press_key" + " ”" + localize _fnc + "“", ((["Better CAS Environment (cTab ATAK Camera)", _id] call CBA_fnc_getKeybind) # -1 # 0) call CBA_fnc_localizeKey]
+        format [localize "STR_BCE_Press_key" + " ”" + localize _fnc + "“", ((["Better CAS Environment (ScreenShot)", _id] call CBA_fnc_getKeybind) # -1 # 0) call CBA_fnc_localizeKey]
       };
 
       _ctrl_hint ctrlSetText (_bnt_Hint joinString " | ");

--- a/addons/cTab/functions/ATAK/Camera/fn_ATAK_TakePicture.sqf
+++ b/addons/cTab/functions/ATAK/Camera/fn_ATAK_TakePicture.sqf
@@ -1,8 +1,5 @@
 #include "script_component.hpp"
 
-private _time = systemTime apply {(["","0"] select (_x < 10)) + (str _x)};
-_time resize 6;
-
 private _display = uiNamespace getVariable ["BCE_PhoneCAM_View",displayNull];
 
 //- Print Grid
@@ -21,16 +18,11 @@ private _ctrls = (allControls _display) apply {
   };
 };
 
-private _fileName = (_time joinString "_") + ".jpg";
-private _fileDir = format [
-	"%1%2", 
-	[(BCE_PicFilePath_edit trim ["\", 2]) + "\",""] select (BCE_PicFilePath_edit == ""), 
-	_fileName
-];
 
 [{
-  params ["_fileDir","_fileName","_ctrls", "_grid"];
-  _return = toString parseSimpleArray ("Arma_ScreenShot_Extension" callExtension str (toArray _fileDir));
+  params ["_ctrls", "_grid"];
+	
+	private _screenshot = [] call BCE_fnc_screenShot; //- Take picture
   
   {
     if (isNull _x) then {continue};
@@ -41,62 +33,14 @@ private _fileDir = format [
   _grid ctrlSetText "";
 
   //- Exit it if ERROR
-  if ("error" in toLowerANSI _return) exitwith {
-    systemChat str format ["ERROR from Taking Pictrue. %1", _return];
-  };
+  if (_screenshot isEqualTo []) exitwith {};
 
   playSound3D [QPATHTOEF(Core,sound\CameraShutter.wss), player, false, getPosASL player, 3, 1, 15];
 
-  //- #FIXME - Add CBA_EH to trigger this 👇
-  if !(BCE_SSE_Webhook_Send_fn) exitWith {};
-  [
-    {
-      params ["_fileDir","_fileName","_unit","_map"];
-      ([_unit] call BCE_fnc_getUnitParams) params ["","_unitName","_title"];
-      //- Send Discord Message
-      [
-        BCE_SSE_Webhook_list,
-        "",
-        "",
-        "",
-        false,
-        _fileDir,
-        [
-          //- Embeds
-          [
-            format [localize "STR_BCE_SSE_OPERATION_NAME", missionName], //- [Title]
-            "", //- [Description]
-            "", //- [color]
-            true, //- [timestamp]
-						"", //- [AuthorName]
-						"", //- [AuthorUrl]
-						"", //- [AuthorIconUrl]
-						format ["attachment://%1", _fileName] //- [ImageUrl]
-          ]
-        ],
-        [ //- Fields for each Embed
-          [
-            [localize "STR_BCE_SSE_SERVER_NAME", format["`%1`",serverName], false],
-            [localize "STR_BCE_SSE_FROM", format ["```%1%2```", profileName, ["[" + _unitName + "]", ""] select (_unitName == "")],true],
-            ["", "",true],
-            [format["“%1” :",_map], format ["```%1```", _unit call BIS_fnc_locationDescription],true],
-            ["","",false],
-            [localize "STR_BCE_SSE_UNIT", format ["```%1```", [_title, localize "str_special_none"] select (_title == "")],true]
-          ]
-        ]
-      ] call DiscordAPI_fnc_sendMessage;
-    },
-    [
-      _return,
-			_fileName,
-      player,
-      worldName
-    ],1
-  ] call CBA_fnc_waitAndExecute;
+  //- CBA_EH to trigger this 👇
+	["bce_took_screenshot", _screenshot] call CBA_fnc_localEvent; //- upload to discord
 },
   [
-    _fileDir,
-		_fileName,
     _ctrls, 
     _grid
   ], 0.2

--- a/addons/cTab/functions/ATAK/Camera/fn_ATAK_TakePicture.sqf
+++ b/addons/cTab/functions/ATAK/Camera/fn_ATAK_TakePicture.sqf
@@ -21,9 +21,16 @@ private _ctrls = (allControls _display) apply {
   };
 };
 
+private _fileName = (_time joinString "_") + ".jpg";
+private _fileDir = format [
+	"%1%2", 
+	[(BCE_PicFilePath_edit trim ["\", 2]) + "\",""] select (BCE_PicFilePath_edit == ""), 
+	_fileName
+];
+
 [{
-  params ["_file","_ctrls", "_grid"];
-  _return = toString parseSimpleArray ("Arma_ScreenShot_Extension" callExtension str (toArray _file));
+  params ["_fileDir","_fileName","_ctrls", "_grid"];
+  _return = toString parseSimpleArray ("Arma_ScreenShot_Extension" callExtension str (toArray _fileDir));
   
   {
     if (isNull _x) then {continue};
@@ -44,7 +51,7 @@ private _ctrls = (allControls _display) apply {
   if !(BCE_SSE_Webhook_Send_fn) exitWith {};
   [
     {
-      params ["_file","_unit","_map"];
+      params ["_fileDir","_fileName","_unit","_map"];
       ([_unit] call BCE_fnc_getUnitParams) params ["","_unitName","_title"];
       //- Send Discord Message
       [
@@ -53,14 +60,18 @@ private _ctrls = (allControls _display) apply {
         "",
         "",
         false,
-        _file,
+        _fileDir,
         [
           //- Embeds
           [
-            format [localize "STR_BCE_SSE_OPERATION_NAME", missionName],
-            "",
-            "",
-            true
+            format [localize "STR_BCE_SSE_OPERATION_NAME", missionName], //- [Title]
+            "", //- [Description]
+            "", //- [color]
+            true, //- [timestamp]
+						"", //- [AuthorName]
+						"", //- [AuthorUrl]
+						"", //- [AuthorIconUrl]
+						format ["attachment://%1", _fileName] //- [ImageUrl]
           ]
         ],
         [ //- Fields for each Embed
@@ -77,17 +88,15 @@ private _ctrls = (allControls _display) apply {
     },
     [
       _return,
+			_fileName,
       player,
       worldName
     ],1
   ] call CBA_fnc_waitAndExecute;
 },
   [
-    format [
-      "%1%2.jpg", 
-      [(BCE_PicFilePath_edit trim ["\", 2]) + "\",""] select (BCE_PicFilePath_edit == ""), 
-      _time joinString "_"
-    ], 
+    _fileDir,
+		_fileName,
     _ctrls, 
     _grid
   ], 0.2

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -21,7 +21,7 @@
 #include "macro.hpp"
 #include "has_cTab.hpp"
 
-/* #ifdef DISABLE_COMPILE_CACHE
+#ifdef DISABLE_COMPILE_CACHE
     #undef PREP
     #define PREP(fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(functions\DOUBLES(fnc,fncName).sqf)
     #undef PREPMAIN
@@ -31,4 +31,4 @@
     #define PREP(fncName) [QPATHTOF(functions\DOUBLES(fnc,fncName).sqf), QFUNC(fncName)] call CBA_fnc_compileFunction
     #undef PREPMAIN
     #define PREPMAIN(fncName) [QPATHTOF(functions\DOUBLES(fnc,fncName).sqf), QFUNCMAIN(fncName)] call CBA_fnc_compileFunction
-#endif */
+#endif

--- a/include/DSLR/functions/rsc/constants.h
+++ b/include/DSLR/functions/rsc/constants.h
@@ -1,0 +1,16 @@
+#define INCLUDED_INFO_TYPES ["Rsc_LALA_HATE_DSLR_HUD",""]
+
+#define LALA_HATE_UI_DISPLAY_VAR "Lala_Hate_DSLR_UI_Display"
+#define LALA_HATE_UI_PFH_VAR "Lala_Hate_DSLR_PFH_Display"
+#define LALA_HATE_UI_UNIT_VAR "Lala_Hate_DSLR_Unit"
+
+#define LALA_HATE_FLASH_PATH_ON		"\DSLR\textures\flash.paa"
+#define LALA_HATE_FLASH_PATH_OFF	"\DSLR\textures\no_flash.paa"
+
+#define LALA_HATE_FLASH_ENABLED_VAR	"Lala_Hate_DSLR_Flash_Enabled"
+#define LALA_HATE_FLASH_ENABLED_DEFAULT_VALUE	FALSE
+
+#define LALA_HATE_FLASH_DISPLAY_TIMEOUT	2
+#define LALA_HATE_FLASH_DISPLAY_TIMEOUT_TIMELEFT_VAR	"Lala_Hate_DSLR_flash_timeout_timeleft"
+
+#define LALA_HATE_RSC_FLASH_ID 21011


### PR DESCRIPTION
It looks better

# After
<img width="369" height="350" alt="image" src="https://github.com/user-attachments/assets/2c2fe6e5-7845-434f-8a3d-3aeda8d7827d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-driven screenshot capture with optional Discord upload via SSE.
  * DSLR compatibility: shutter sound and optional flash effect when taking pictures.

* **Bug Fixes**
  * More reliable screenshot capture and naming to reduce failures/conflicts.

* **Chores**
  * UI/keybind labels updated to reference "ScreenShot" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->