### PR TITLE
Exclude "boundingBoxMarker_" for cTab

### DIFF
--- a/addons/Compat_cTab/functions/fn_findUserMarker.sqf
+++ b/addons/Compat_cTab/functions/fn_findUserMarker.sqf
@@ -53,7 +53,7 @@ private _maxDistance = _searchPos distanceSqr [(_searchPos # 0) + _targetRadius,
 
 (ctrlMapMouseOver _ctrl) params ["_overType","_overEntity"];
 
-if (_overType isEqualTo "marker") exitWith {
+if (_overType isEqualTo "marker" && cTabMarkerList isNotEqualTo []) exitWith {
 	private _sel = cTabMarkerList findIf {(_x # 0) isEqualTo _overEntity};
 	
 	cTabMarkerList # _sel # 2;

--- a/addons/Compat_cTab/functions/fn_updateUserMarkerList.sqf
+++ b/addons/Compat_cTab/functions/fn_updateUserMarkerList.sqf
@@ -19,15 +19,18 @@
 
 if (isNil "cTabIfOpen") exitWith {false};
 
+//- Skip on (Prefix "-") or (POLPOX's MapTool Markers)
+private _allMarkers = allMapMarkers select {
+	!(
+		((_x select [0,1]) isEqualTo "-") ||
+		("boundingBoxMarker_" in _x) ||
+		("PLP_" in _x)
+	)
+};
+
 private _list = [];
 {
   private _marker = _x;
-
-  //- Skip on (Prefix "-") or (POLPOX's MapTool Markers)
-		if (
-      _marker select [0,1] == "-" ||
-			("PLP_" in _marker)
-    ) then {continue};
   
   private _markerShape = ["ICON","RECTANGLE","ELLIPSE","POLYLINE"] find (MarkerShape _marker);
   ((markerType _marker) call BCE_fnc_getMarkerItem) params ["_name","_icon","_shadow","_size"];
@@ -81,7 +84,7 @@ private _list = [];
 	];
   
   _list pushBack _result;
-} forEach allMapMarkers;
+} forEach _allMarkers;
 
 cTabMarkerList = _list;
 _list = nil;


### PR DESCRIPTION
Check issue #61

`boundingBoxMarker_` markers which are created by `BIS_fnc_boundingBoxMarker`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marker filtering logic to correctly exclude unwanted markers from the map interface, enhancing performance and preventing display of internal utility markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->