### PR TITLE
Exclude Hatchet H-60 JVMF compatibility except for marker system from BCE

### DIFF
--- a/addons/Compat_Hatchet/config.cpp
+++ b/addons/Compat_Hatchet/config.cpp
@@ -8,6 +8,7 @@ class CfgPatches {
 		//- #NOTE : Hatchet H-60
 		requiredAddons[]=
 		{
+			QEGVAR(Compat,cTab),
 			"vtx_uh60_jvmf"
 		};
 		skipWhenMissingDependencies = 1;


### PR DESCRIPTION
Limit the compatibility of the Hatchet H-60 to only the marker system from BCE which is built for **cTab 1erGTD** to ensure other cTab distros won't be affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated addon dependencies to ensure proper module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->