### PR TITLE
Fix addon identifier for MapTools compatibility

### DIFF
--- a/addons/Compat_MapTools/SUB_Addons/cTab_MapTools_Compat/config.cpp
+++ b/addons/Compat_MapTools/SUB_Addons/cTab_MapTools_Compat/config.cpp
@@ -6,11 +6,10 @@ class CfgPatches {
 		url = ECSTRING(main,url);
 		addonRootClass = QUOTE(ADDON);
 		requiredVersion = REQUIRED_VERSION;
-		//- #NOTE : BCE_cTab
 		requiredAddons[]=
 		{
 			QADDON,
-			QGVARMAIN(cTab)
+			QGVARMAIN(cTab_UI) //- #NOTE : BCE_cTab_UI
 		};
 		skipWhenMissingDependencies = 1;
 		units[] = {};


### PR DESCRIPTION
Renames the main addon identifier to ensure compatibility with MapTools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compatibility requirements to reference the correct cTab UI component, improving addon loading and interoperability with MapTools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->