### PR TITLE
Fix ATAK compass hides behind map control

### DIFF
--- a/addons/cTab_UI/UI/Devices/cTab_Android.hpp
+++ b/addons/cTab_UI/UI/Devices/cTab_Android.hpp
@@ -146,28 +146,7 @@ PHONE_CLASS
 			w = QUOTE(((((((PHONE_MOD) - (20) * 2) - (10) * 3) / 3) * 2)) / 2048 * PhoneW);
 			h = QUOTE(((((626) - (60) - (10) * 2) - (20) -(10))) / 2048 * CustomPhoneH);
 		};
-		//- Add Compass
-			class Compass: cTab_android_on_screen_battery
-			{
-				idc = idc_D(2615);
-				style = "0x02 + 0x30 + 0x800";
-				text = QPATHTOEF(Core,data\Compass.paa);
-				y = QUOTE(((713)) / 2048 * CustomPhoneH + CustomPhoneY + (((60)) / 2048 * CustomPhoneH));
-				w = QUOTE(1.3 * sizeW * (PhoneW * 3/4));
-				h = QUOTE(1.3 * sizeW * PhoneW);
-			};
-			class compass_Dir: cTab_RscText_Android
-			{
-				idc = idc_D(2616);
-				style = 2;
-				shadow = 1;
-				text = "N";
-				sizeEx = QUOTE(0.6 * sizeW * PhoneW);
-				x = QUOTE(((((20) + (452)) + ((20) + (((PHONE_MOD) - (20) * 6) / 5)) * (1 - 1))) / 2048  * 	PhoneW + 	CustomPhoneX);
-				y = QUOTE(((713)) / 2048 * CustomPhoneH + CustomPhoneY + (((60)) / 2048 * CustomPhoneH));
-				w = QUOTE(1.3 * sizeW * (PhoneW * 3/4));
-				h = QUOTE(1.3 * sizeW * PhoneW);
-			};
+		
 	};
 	class controls
 	{
@@ -448,6 +427,29 @@ PHONE_CLASS
 				idc = idc_D(2622);
 				text = "GRID :";
 				y = QUOTE(BOX_POS_Y(1));
+			};
+
+		//- Add Compass
+			class Compass: cTab_android_on_screen_battery
+			{
+				idc = idc_D(2615);
+				style = "0x02 + 0x30 + 0x800";
+				text = QPATHTOEF(Core,data\Compass.paa);
+				y = QUOTE(((713)) / 2048 * CustomPhoneH + CustomPhoneY + (((60)) / 2048 * CustomPhoneH));
+				w = QUOTE(1.3 * sizeW * (PhoneW * 3/4));
+				h = QUOTE(1.3 * sizeW * PhoneW);
+			};
+			class compass_Dir: cTab_RscText_Android
+			{
+				idc = idc_D(2616);
+				style = 2;
+				shadow = 1;
+				text = "N";
+				sizeEx = QUOTE(0.6 * sizeW * PhoneW);
+				x = QUOTE(((((20) + (452)) + ((20) + (((PHONE_MOD) - (20) * 6) / 5)) * (1 - 1))) / 2048  * 	PhoneW + 	CustomPhoneX);
+				y = QUOTE(((713)) / 2048 * CustomPhoneH + CustomPhoneY + (((60)) / 2048 * CustomPhoneH));
+				w = QUOTE(1.3 * sizeW * (PhoneW * 3/4));
+				h = QUOTE(1.3 * sizeW * PhoneW);
 			};
 
 		//- Pages for ATAK


### PR DESCRIPTION
Move definitions from `backgroundControls` to `controls`.